### PR TITLE
Fixed JQuery Google API-link

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
 	</div>
 
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.1.min.js"><\/script>')</script>
 
 <script src="js/script.js"></script>


### PR DESCRIPTION
Without "https:" the request can time out after a couple of seconds without receiving the file, and use the local file instead.