### PR TITLE
Remove IE Chrome frame for very old IE (no longer works)

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,11 +196,5 @@
 	g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
 	s.parentNode.insertBefore(g,s)}(document,'script'));
 </script>
-
-<!--[if lt IE 7 ]>
-	<script src="//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.2/CFInstall.min.js"></script>
-	<script>window.attachEvent("onload",function(){CFInstall.check({mode:"overlay"})})</script>
-<![endif]-->
-
 </body>
 </html>


### PR DESCRIPTION
Chrome Frame is no longer available.